### PR TITLE
ES6 arrow function added to client.addEvent() callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ exports.handler = (event, context, callback) => {
             let apiLog = parse(result);
             
             // sending this log to Keen IO 
-            client.addEvent("event", apiLog, function(err, res) => {
+            client.addEvent("event", apiLog, (err, res) => {
                 if (err) {
                     callback(err);
                 } else {

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ exports.handler = (event, context, callback) => {
             let apiLog = parse(result);
             
             // sending this log to Keen IO 
-            client.addEvent("event", apiLog, function(err, res) {
+            client.addEvent("event", apiLog, function(err, res) => {
                 if (err) {
                     callback(err);
                 } else {


### PR DESCRIPTION
@mabdullah353 I just found an arrow function => missing in line # 33 of index.js in callback function of client.addEvent(). Please have a review and pull it in the original repo to make it more ES6 friendly
